### PR TITLE
Update README to correctly configure "magento-dir"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Config
         enabled:
             - Codeception\Extension\RunFailed
             - Magento\Codeception\Extension\Magento
-        config:
-            Magento\Codeception\Extension\Magento:
-                magento-dir: 'src'
+                  magento-dir: 'src'
 
 **unit.suite.yml**
 


### PR DESCRIPTION
On latest Codeception (likely earlier versions too), extensions are configured by providing config options directly when enabling the extension rather than via a separate entry under the "config" section.

The config as per previous version of README was ignored by Codeception, while the one in this updated README works correctly.